### PR TITLE
🎉  Support passing spec a JSON object

### DIFF
--- a/packages/gatsby-theme-parliament/src/components/OpenAPIBlock.js
+++ b/packages/gatsby-theme-parliament/src/components/OpenAPIBlock.js
@@ -15,8 +15,9 @@ import { css } from '@emotion/core';
 import { ProgressCircle } from '@react-spectrum/progress';
 import { RedocStandalone } from 'redoc';
 
-export const OpenAPIBlock = ({ specUrl }) => {
+export const OpenAPIBlock = ({ specUrl, spec }) => {
   const [showProgress, setShowProgress] = useState(true);
+  let input = specUrl ? { specUrl } : { spec };
 
   return (
     <div
@@ -732,7 +733,7 @@ export const OpenAPIBlock = ({ specUrl }) => {
           }
         `}>
         <RedocStandalone
-          specUrl={specUrl}
+          {...input}
           options={{
             nativeScrollbars: true,
             disableSearch: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Enhances the OpenAPIBlock to be able to accept a spec object as well as a spec url.

## Related Issue

n/a

## Motivation and Context

Flexibility mostly. Having the spec in the project will enable it to be enhanced with things like code samples and will enable easier searching.

## How Has This Been Tested?

I whipped through the specs at: https://github.com/OAI/OpenAPI-Specification/tree/master/examples

Passing them in as `specUrl` and `spec`.

## Screenshots (if appropriate):

n/a the page looks the same regardless of the input.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
