### PR TITLE
fix : sidenavbar path fix

### DIFF
--- a/packages/gatsby-theme-aio/package.json
+++ b/packages/gatsby-theme-aio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/gatsby-theme-aio",
-  "version": "4.15.4",
+  "version": "4.15.5-rc1",
   "description": "The Adobe I/O theme for building markdown powered sites",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/gatsby-theme-aio/package.json
+++ b/packages/gatsby-theme-aio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/gatsby-theme-aio",
-  "version": "4.15.5-rc1",
+  "version": "4.15.5-rc2",
   "description": "The Adobe I/O theme for building markdown powered sites",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/gatsby-theme-aio/src/components/SideNav/index.js
+++ b/packages/gatsby-theme-aio/src/components/SideNav/index.js
@@ -12,7 +12,8 @@
 
 import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { Link as GatsbyLink } from 'gatsby';
+import { withPrefix } from 'gatsby';
+import { GatsbyLink } from '../GatsbyLink';
 import { isBrowser,   findSelectedTopPage,
   findSelectedTopPageMenu,
   rootFix,
@@ -156,7 +157,7 @@ const SideNav = ({versions, mainNavPages, selectedPages, selectedSubPages, setSh
                     setShowSideNav(false);
                   }
                 }}
-                to={pageHref}
+                to={withPrefix(pageHref)}
                 className="spectrum-SideNav-itemLink"
                 daa-ll={page.title}>
                 {page.title}
@@ -258,7 +259,7 @@ const SideNav = ({versions, mainNavPages, selectedPages, selectedSubPages, setSh
                     setShowSideNav(false);
                   }
                 }}
-                to={pageHref}
+                to={withPrefix(pageHref)}
                 className="spectrum-SideNav-itemLink"
                 daa-ll={page.title}>
                 { selectedMenuItem === page  && <CheckMark /> }


### PR DESCRIPTION
## Description

I encountered an issue with the side navbar: when we switch to a mobile device and click the URL, it doesn’t work as expected. I fixed the issue on the Embed SDK marketing site. At first I thought it was in `gatsby-config`, but I found it in the theme issue, so I created a shadow component and fixed the issue. I’ve moved my changes to production — you can verify them on the Embed SDK marketing site.

## FYR 

https://developer.adobe.com/express/embed-sdk/
https://github.com/AdobeDocs/create-embed-sdk/blob/main/src/%40adobe/gatsby-theme-aio/components/SideNav/index.js

